### PR TITLE
Zoom improvements

### DIFF
--- a/app/styles/global.css
+++ b/app/styles/global.css
@@ -27,10 +27,11 @@
 	--button-base: #202b38;
 }
 
-body { 
+body {
 	max-width: 100%;
 	line-height: 1.5;
 	margin: 0;
 	padding: 0;
 	background-color: var(--black);
+  overscroll-behavior-x: none;
 }


### PR DESCRIPTION
* Disable browser "back" action on two-finger swipe
* Handle Safari's `gesture` events and translate them to `wheel` events so that `react-zoom-pan-pinch` can handle them